### PR TITLE
Update command for launching privacy center through ECS

### DIFF
--- a/fides-aws-ecs/ecs-privacy-center.tf
+++ b/fides-aws-ecs/ecs-privacy-center.tf
@@ -12,8 +12,7 @@ locals {
         apk add --no-cache aws-cli sudo \
           && aws s3 cp s3://${aws_s3_bucket.privacy_center_config.bucket}/${aws_s3_object.config_json.id} /app/config/config.json \
           && aws s3 cp s3://${aws_s3_bucket.privacy_center_config.bucket}/${aws_s3_object.config_css.id} /app/config/config.css \
-          && npm config set color false \
-          && sudo -u nextjs ./start.sh
+          && npm run start
         COMMAND
       ]
       portMappings = [


### PR DESCRIPTION
This updates the command to launch privacy center through ECS. Per @RobertKeyser on this thread: https://ethyca.slack.com/archives/C077YRPN8P8/p1721764614237569

There are two things that change here. 
- First, we remove `npm config set color false` part 
- We no longer use a special start.sh script, but just the `npm run start` command directly.