### PR TITLE
feat: update route_53 validation statements to permit default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-## [1.0.3] - 2025-05-27
+## [1.0.3] - 2025-06-04
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [1.0.2] - 2025-05-27
 
+### Fixed
+
+- Updated validation logic for route53_config to permit default value, allowing non-prod plans to pass without DNS configuration
+
+## [1.0.2] - 2025-05-27
+
 This release does not include changes to the Terraform module itself.
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixed
 
-## [1.0.2] - 2025-05-27
+## [1.0.3] - 2025-05-27
 
 ### Fixed
 

--- a/fides-aws-ecs/variables.tf
+++ b/fides-aws-ecs/variables.tf
@@ -106,17 +106,17 @@ variable "route53_config" {
   default = null
 
   validation {
-    condition     = var.route53_config.fides_subdomain != "" && var.route53_config.privacy_center_subdomain != "" && var.route53_config.existing_hosted_zone_name != ""
+    condition     = var.route53_config == null ? true : var.route53_config.fides_subdomain != "" && var.route53_config.privacy_center_subdomain != "" && var.route53_config.existing_hosted_zone_name != ""
     error_message = "the value of \"var.route53_config.fides_subdomain\" and \"var.route53_config.privacy_center_subdomain\" must not be empty."
   }
 
   validation {
-    condition     = endswith(var.route53_config.fides_subdomain, var.route53_config.existing_hosted_zone_name)
+    condition     = var.route53_config == null ? true : endswith(var.route53_config.fides_subdomain, var.route53_config.existing_hosted_zone_name)
     error_message = "the value of \"var.route53_config.fides_subdomain\" must be a subdomain of \"var.route53_config.existing_hosted_zone_name\"."
   }
 
   validation {
-    condition     = endswith(var.route53_config.privacy_center_subdomain, var.route53_config.existing_hosted_zone_name)
+    condition     = var.route53_config == null ? true : endswith(var.route53_config.privacy_center_subdomain, var.route53_config.existing_hosted_zone_name)
     error_message = "the value of \"var.route53_config.privacy_center_subdomain\" must be a subdomain of \"var.route53_config.existing_hosted_zone_name\"."
   }
 }

--- a/fides-aws-ecs/version.json
+++ b/fides-aws-ecs/version.json
@@ -1,5 +1,5 @@
 {
     "module": "fides-aws-ecs",
     "name": "Fides AWS ECS",
-    "version": "1.0.2"
+    "version": "1.0.3"
 }


### PR DESCRIPTION
When route53_config is set to null (the default), the validation tried to access properties of a null value, causing an error.

The changes fix the issue by adding a null check before trying to access properties of route53_config. Now when route53_config is null (which is the default), the validation will pass instead of throwing an error.